### PR TITLE
Lock the version of boto3, botocore and awscli.

### DIFF
--- a/provisioners/aem-platform-buildenv-sandpit.pp
+++ b/provisioners/aem-platform-buildenv-sandpit.pp
@@ -12,9 +12,16 @@ pip::install { 'aws-google-auth[u2f]':
   python_version => '2.7',
 } -> pip::install { 'botocore':
   ensure         => present,
-  version        => '1.12.123', # most recent 1.11.x required by aws-google-auth due to range < 1.12
+  version        => '1.11.9', # most recent 1.11.x required by aws-google-auth due to range < 1.12, 
+  python_version => '2.7',
+} -> pip::install { 'boto3':
+  ensure         => present,
+  version        => '1.8.5',
   python_version => '2.7',
 }
+
+# awscli 1.16.10 has requirement botocore==1.12.0, but you'll have botocore 1.11.9 which is incompatible.
+# May need to change boto3 to 1.8.6 and botocore to 1.12.0 later.
 
 class { 'cred::google':
 }

--- a/provisioners/aem-platform-buildenv.pp
+++ b/provisioners/aem-platform-buildenv.pp
@@ -19,7 +19,7 @@ pip::install { 'ansible':
 }
 pip::install { 'awscli':
   ensure         => present,
-  version        => '1.16.133',
+  version        => '1.16.10',
   python_version => '2.7',
 }
 


### PR DESCRIPTION
Those versions are consistent with ones used in packer-aem.
May need to update boto3 to 1.8.6 to meet awscli-1.16.10 later.