### PR TITLE
fix/Update aem-platform-buildenv.pp to forbid degraded pip installation 

### DIFF
--- a/provisioners/aem-platform-buildenv.pp
+++ b/provisioners/aem-platform-buildenv.pp
@@ -83,7 +83,7 @@ class { 'cred::puppet':
 class { 'python':
   ensure     => 'present',
   dev        => 'present',
-  pip        => 'present',
+  pip        => 'absent',
   virtualenv => 'present',
 }
 


### PR DESCRIPTION
The definition of class python installs an old version of pip and has overwritten the current link of pip executor. So this parameter should be changed to 'absent'. 