### PR TITLE
Added AEM OpenCloud library dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added new shell provisioning script `python.sh` to upgrade pip3 & install ansible
+- Added AEM OpenCloud library dependencies to aem-platform-buildenv so they are included in the docker image and don't need to be resolved
+
+### Changed
+- Upgraded Puppet to 7.9.0
+- Upgraded dependencies in requirements.txt
 
 ## 2.0.0 - 2021-03-01
 ### Changed

--- a/conf/ansible/inventory/group_vars/defaults.yaml
+++ b/conf/ansible/inventory/group_vars/defaults.yaml
@@ -1,3 +1,4 @@
+---
 docker:
   repository: shinesolutions
   timezone: Australia/Melbourne

--- a/conf/ansible/inventory/hosts
+++ b/conf/ansible/inventory/hosts
@@ -1,2 +1,2 @@
 [defaults]
-127.0.0.1 ansible_python_interpreter=python
+127.0.0.1 ansible_python_interpreter=python3

--- a/provisioners/aem-platform-buildenv.pp
+++ b/provisioners/aem-platform-buildenv.pp
@@ -7,77 +7,77 @@ class { '::phantomjs':
 }
 
 # Install Python dependencies
-package { "awscli":
+package { 'awscli':
   ensure   => '1.22.1',
   provider => 'pip3',
 }
-package { "boto":
+package { 'boto':
   ensure   => '2.49.0',
   provider => 'pip3',
 }
-package { "boto3":
+package { 'boto3':
   ensure   => '1.20.0',
   provider => 'pip3',
 }
-package { "botocore":
+package { 'botocore':
   ensure   => '1.23.1',
   provider => 'pip3',
 }
-package { "jinja2":
+package { 'jinja2':
   ensure   => '2.11.3',
   provider => 'pip3',
 }
-package { "pylint":
+package { 'pylint':
   ensure   => '2.6.0',
   provider => 'pip3',
 }
-package { "ruamel.yaml":
+package { 'ruamel.yaml':
   ensure   => '0.16.5',
   provider => 'pip3',
 }
-package { "yamllint":
+package { 'yamllint':
   ensure   => '1.19.0',
   provider => 'pip3',
 }
 
 # Install Ruby dependencies
-package { "bundler":
+package { 'bundler':
   ensure   => '1.17.3',
   provider => 'puppet_gem',
 }
-package { "aws-sdk-core":
+package { 'aws-sdk-core':
   ensure   => '3.50.0',
   provider => 'puppet_gem',
 }
-package { "rake":
+package { 'rake':
   ensure   => '12.3.3',
   provider => 'puppet_gem',
 }
-package { "ruby_aem":
+package { 'ruby_aem':
   ensure   => '3.13.1',
   provider => 'puppet_gem',
 }
-package { "ruby_aem_aws":
+package { 'ruby_aem_aws':
   ensure   => '2.2.1',
   provider => 'puppet_gem',
 }
-package { "inspec":
+package { 'inspec':
   ensure   => '1.51.6',
   provider => 'puppet_gem',
 }
-package { "capybara":
+package { 'capybara':
   ensure   => '3.30.0',
   provider => 'puppet_gem',
 }
-package { "file_utils":
+package { 'file_utils':
   ensure   => '1.1.2',
   provider => 'puppet_gem',
 }
-package { "rspec":
+package { 'rspec':
   ensure   => '3.8.0',
   provider => 'puppet_gem',
 }
-package { "poltergeist":
+package { 'poltergeist':
   ensure   => '1.18.1',
   provider => 'puppet_gem',
 }

--- a/provisioners/aem-platform-buildenv.pp
+++ b/provisioners/aem-platform-buildenv.pp
@@ -5,3 +5,79 @@ class { '::phantomjs':
   source_dir      => '/opt',
   timeout         => 600,
 }
+
+# Install Python dependencies
+package { "awscli":
+  ensure   => '1.22.1',
+  provider => 'pip3',
+}
+package { "boto":
+  ensure   => '2.49.0',
+  provider => 'pip3',
+}
+package { "boto3":
+  ensure   => '1.20.0',
+  provider => 'pip3',
+}
+package { "botocore":
+  ensure   => '1.23.1',
+  provider => 'pip3',
+}
+package { "jinja2":
+  ensure   => '2.11.3',
+  provider => 'pip3',
+}
+package { "pylint":
+  ensure   => '2.6.0',
+  provider => 'pip3',
+}
+package { "ruamel.yaml":
+  ensure   => '0.16.5',
+  provider => 'pip3',
+}
+package { "yamllint":
+  ensure   => '1.19.0',
+  provider => 'pip3',
+}
+
+# Install Ruby dependencies
+package { "bundler":
+  ensure   => '1.17.3',
+  provider => 'puppet_gem',
+}
+package { "aws-sdk-core":
+  ensure   => '3.50.0',
+  provider => 'puppet_gem',
+}
+package { "rake":
+  ensure   => '12.3.3',
+  provider => 'puppet_gem',
+}
+package { "ruby_aem":
+  ensure   => '3.13.1',
+  provider => 'puppet_gem',
+}
+package { "ruby_aem_aws":
+  ensure   => '2.2.1',
+  provider => 'puppet_gem',
+}
+package { "inspec":
+  ensure   => '1.51.6',
+  provider => 'puppet_gem',
+}
+package { "capybara":
+  ensure   => '3.30.0',
+  provider => 'puppet_gem',
+}
+package { "file_utils":
+  ensure   => '1.1.2',
+  provider => 'puppet_gem',
+}
+package { "rspec":
+  ensure   => '3.8.0',
+  provider => 'puppet_gem',
+}
+package { "poltergeist":
+  ensure   => '1.18.1',
+  provider => 'puppet_gem',
+}

--- a/provisioners/puppet.sh
+++ b/provisioners/puppet.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 set -o nounset
 set -o errexit
+PUPPET_MAJOR_VERSION=7
+PUPPET_MINOR_VERSION=9
+PUPPET_PATCH_VERSION=0
+PUPPET_AGENT_VERSION="${PUPPET_MAJOR_VERSION}.${PUPPET_MINOR_VERSION}.${PUPPET_PATCH_VERSION}"
+ARCH_TYPE=x86_64
+OS_TYPE=el
+OS_VERSION=7
 
-rpm -ivh --force https://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
-yum -y install puppet-agent-5.5.22 || echo $?
+if [[ "$(/opt/puppetlabs/puppet/bin/puppet --version)" == "${PUPPET_AGENT_VERSION}" ]]
+then
+    echo "Puppet version ${PUPPET_AGENT_VERSION} is already installed. Skipping Puppet installation..."
+else
+    echo "Installing puppet ${PUPPET_AGENT_VERSION}..."
+    yum -y install "https://yum.puppetlabs.com/puppet${PUPPET_MAJOR_VERSION}/${OS_TYPE}/${OS_VERSION}/${ARCH_TYPE}/puppet-agent-${PUPPET_AGENT_VERSION}-1.${OS_TYPE}${OS_VERSION}.${ARCH_TYPE}.rpm"
+fi
 
 # Info
 /opt/puppetlabs/puppet/bin/ruby --version

--- a/provisioners/python.sh
+++ b/provisioners/python.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -o nounset
+set -o errexit
+
+echo 'Upgrading pip3 to latest version'
+/usr/bin/python3 -m pip install --upgrade pip
+
+echo 'Installing Ansible'
+/usr/local/bin/pip3 install -q ansible==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-ansible==2.9.2
-awscli==1.16.304
-botocore==1.13.40
-boto3==1.10.35
+ansible==4.8.0
+awscli==1.22.1
+boto==2.49.0
+boto3==1.20.0
+botocore==1.23.1
 docker-py==1.10.6
 yamllint==1.19.0

--- a/templates/docker-base.json
+++ b/templates/docker-base.json
@@ -14,6 +14,12 @@
         "--privileged",
         "-e",
         "container=docker",
+        "-e",
+        "LANG=en_US.UTF-8",
+        "-e",
+        "LC_ALL=en_US.UTF-8",
+        "-e",
+        "LC_CTYPE=en_US.UTF-8",
         "-v",
         "/sys/fs/cgroup:/sys/fs/cgroup",
         "-d",
@@ -23,7 +29,9 @@
         "/usr/bin/bash"
       ],
       "changes": [
-        "ENV LANG en_US.UTF-8",
+        "ENV LANG UTF-8",
+        "ENV LC_ALL en_US.UTF-8",
+        "ENV LC_CTYPE en_US.UTF-8",
         "ENV TZ {{user `timezone`}}",
         "ENV PATH /opt/puppetlabs/puppet/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "EXPOSE 4502 4503 5432 5433"
@@ -35,6 +43,10 @@
       "type": "shell",
       "script": "provisioners/puppet.sh"
     },
+      {
+        "type": "shell",
+        "script": "provisioners/python.sh"
+      },
     {
       "type": "puppet-masterless",
       "prevent_sudo": true,


### PR DESCRIPTION
### Added
- Added new shell provisioning script `python.sh` to upgrade pip3 & install ansible
- Added AEM OpenCloud library dependencies to aem-platform-buildenv so they are included in the docker image and don't need to be resolved

### Changed
- Upgraded Puppet to 7.9.0
- Upgraded dependencies in requirements.txt